### PR TITLE
feat!: More granular exclusion options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ require('streamer-mode').setup({
   paths = {
     '*',
   },
+  -- Exclude all the default keywords and only use the ones you specify
+  exclude_all_default_keywords = false, -- | true
+
+  -- Only exclude the given keywords from the default values
+  exclude_default_keywords = { 'keyword1', 'keyword2' },
+
+  -- Exclude the default path (which is '*', all paths) and only use the ones you specify
+  exclude_all_default_paths = true, 
 
   -- Any text appearing after one of the keywords specified here will be concealed.  
   -- They are case-insensitive.  
@@ -199,10 +207,15 @@ require('streamer-mode').setup({
 
 ##### All optional. Simply calling `require('streamer-mode').setup()` will use the defaults.  
 
-* `use_defaults` (Boolean): Whether or not to use the default paths and keywords.  
+* Deprecated - `use_defaults` (Boolean): Whether or not to use the default paths and keywords.  
     * If you do not specify this parameter, it will default to `true`.  
     * Note that if this is not set to `false`, then any custom `paths` and `keywords`  
       will be used **in addition** to the default paths and keywords.  
+* `exclude_default_keywords` (List-like table): The default values of `keywords` that
+  will **not** be used.  
+* `exclude_all_default_keywords` (Boolean): Whether or not to use default keywords.  
+    - `true`: Does not use any of the defaults, only what you specify in `.setup()`.  
+    - `false` (default): Use the default keywords.  
 * `keywords` (List-like Table): Keywords that will be concealed.  
     * Any text that appears **after** one of these keywords will be concealed 
       with `conceal_char` (default is `*`).  
@@ -280,13 +293,19 @@ require('streamer-mode').setup({
 ### Example Custom Setup  
 
 Here's an example of a custom configuration.  
-Note that passing in your own `paths` and `keywords` will disable the  
-default paths and keywords, unless you also pass in `use_defaults = true`.  
+
+
+Note that all the default `paths` and `keywords` will be used unless explicitly disabled:
+* `exclude_all_default_keywords = true` or `exclude_default_keywords = { 'keyword1', 'keyword2' }` etc.  
+* `exclude_all_default_paths = true` (there is only one value here, `'*'`).  
+* `use_defaults = true` is being deprecated, since this is the default behavior.  
 
 ```lua  
 require('streamer-mode').setup({
   -- Use the default paths and keywords in addition to your own.  
-  use_defaults = true,  
+  use_defaults = true,  -- Deprecated, use the 'exclude' options
+  exclude_default_keywords = { 'alias', 'export' },
+  exclude_all_default_paths = true, 
   paths = {
     -- While working in buffers that match any path or filetype listed here,
     -- streamer-mode will conceal all keywords in the `keywords` table.  

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Call `:StreamerModeOff` (`:SMoff`) to disable Streamer Mode, or simply toggle it
 
 Streamer Mode will be off be default, unless `default_state = 'on'` is passed during [setup](#setup)).  
 To toggle it on, use the command `:SM`, or `:SM(level)`.  
+
 Here's an example of binding it to a key:  
 ```lua  
 vim.keymap.set('n', '<leader>sm', '<cmd>SM<CR>', { silent = true })  
@@ -155,17 +156,18 @@ require('streamer-mode').setup({
   -- Streamer Mode will apply to any path in here. Defaults to all paths. 
   -- This means that Streamer Mode will hide any of the `keywords` below 
   -- when inside any of these directories or filetypes.  
-  paths = {
-    '*',
-  },
+  paths = { '*' },
   -- Exclude all the default keywords and only use the ones you specify
   exclude_all_default_keywords = false, -- | true
 
   -- Only exclude the given keywords from the default values
-  exclude_default_keywords = { 'keyword1', 'keyword2' },
+  exclude_default_keywords = {},
 
   -- Exclude the default path (which is '*', all paths) and only use the ones you specify
-  exclude_all_default_paths = true, 
+  exclude_default_paths = false, 
+
+  -- Same as `exclude_default_paths`
+  exclude_all_default_paths = false, 
 
   -- Any text appearing after one of the keywords specified here will be concealed.  
   -- They are case-insensitive.  
@@ -195,7 +197,6 @@ require('streamer-mode').setup({
 
   level = 'secure', -- | 'edit' | 'soft'  
   default_state = 'off', -- Whether or not streamer mode turns on when nvim is launched.  
-  conceal_char = '*',
 
   conceal_char = '*',  -- Default. This is what will be displayed instead  
                        -- of your secrets.  
@@ -207,10 +208,8 @@ require('streamer-mode').setup({
 
 ##### All optional. Simply calling `require('streamer-mode').setup()` will use the defaults.  
 
-* Deprecated - `use_defaults` (Boolean): Whether or not to use the default paths and keywords.  
-    * If you do not specify this parameter, it will default to `true`.  
-    * Note that if this is not set to `false`, then any custom `paths` and `keywords`  
-      will be used **in addition** to the default paths and keywords.  
+* **DEPRECATED** - `use_defaults` (Boolean): Whether or not to use the default paths and keywords.  
+    - Use the `exclude` options instead. This will have no effect.
 * `exclude_default_keywords` (List-like table): The default values of `keywords` that
   will **not** be used.  
 * `exclude_all_default_keywords` (Boolean): Whether or not to use default keywords.  
@@ -221,6 +220,7 @@ require('streamer-mode').setup({
       with `conceal_char` (default is `*`).  
     * It is possible to pass a Vim basic regular expression (BRE) as a keyword.  
 * `paths` (List-like Table): The paths and filetypes that Streamer Mode will apply to.  
+    * Globbing with `*` is supported.  
     * Pass in paths in the format: `paths = { '*/path/*' }`
     * Pass in filetypes in the same format: ` paths = { '*.txt' }`
 * `level` (String): The level in which Streamer Mode will be in effect.  
@@ -297,13 +297,14 @@ Here's an example of a custom configuration.
 
 Note that all the default `paths` and `keywords` will be used unless explicitly disabled:
 * `exclude_all_default_keywords = true` or `exclude_default_keywords = { 'keyword1', 'keyword2' }` etc.  
-* `exclude_all_default_paths = true` (there is only one value here, `'*'`).  
+* `exclude_default_paths = true` (there is only one value here, `'*'`).  
+    * `exclude_all_default_paths = true` will work too.  
 * `use_defaults = true` is being deprecated, since this is the default behavior.  
 
 ```lua  
 require('streamer-mode').setup({
   -- Use the default paths and keywords in addition to your own.  
-  use_defaults = true,  -- Deprecated, use the 'exclude' options
+  use_defaults = true,  -- Deprecated, use the 'exclude' options instead.
   exclude_default_keywords = { 'alias', 'export' },
   exclude_all_default_paths = true, 
   paths = {
@@ -345,7 +346,7 @@ There are three different levels, each with different behavior.
 * `'edit'` will allow the concealed text to become visible  
   only when the cursor goes into insert mode on the same line.  
 * `'soft'` will allow the concealed text to become visible  
-when the cursor is on the same line in any mode.  
+  when the cursor is on the same line in any mode.  
 
 
 

--- a/doc/streamer-mode.txt
+++ b/doc/streamer-mode.txt
@@ -32,8 +32,17 @@ streamer-mode.setup({opts})
     An example of a custom configuration might look something like this:
 
     require('streamer-mode').setup{
-	-- Use default keywords in addition to your own
-	use_defaults = true,
+	use_defaults = true, -- Deprecated. Use the 'exclude' options instead.
+
+	-- Exclude all the default keywords and only use the ones you specify.
+	exclude_all_default_keywords = false, -- | true
+
+	-- Use defaults, but exclude the given keywords from the default values.
+	exclude_default_keywords = { 'alias', 'user.name' },
+
+	-- Exclude the default path (which is '*', all paths) and only use the 
+	-- ones you specify.
+	exclude_all_default_paths = true, 
         keywords = {
           'address',
           'phone_number',
@@ -44,14 +53,14 @@ streamer-mode.setup({opts})
 	paths = {
         -- Defaults to all paths and filetypes:
 	    '*',
-      },
+        },
 
-      level = 'secure', -- | 'edit' | 'soft' (see more info below)
+        level = 'secure', -- | 'edit' | 'soft' (see more info below)
 
-      default_state = 'off',  -- | 'on' : Whether or not streamer mode turns
+        default_state = 'off',  -- | 'on' : Whether or not streamer mode turns
                              --           on when nvim is launched.
 
-      conceal_char = '*'  -- Default. This is what will be displayed instead
+        conceal_char = '*'  -- Default. This is what will be displayed instead
 			  -- of your secrets.
     })
 <

--- a/doc/streamer-mode.txt
+++ b/doc/streamer-mode.txt
@@ -42,7 +42,9 @@ streamer-mode.setup({opts})
 
 	-- Exclude the default path (which is '*', all paths) and only use the 
 	-- ones you specify.
-	exclude_all_default_paths = true, 
+	exclude_default_paths = true,
+	exclude_all_default_paths = true, -- Same as above
+
         keywords = {
           'address',
           'phone_number',
@@ -50,10 +52,8 @@ streamer-mode.setup({opts})
           'SSN',
           'email',
         },
-	paths = {
         -- Defaults to all paths and filetypes:
-	    '*',
-        },
+	paths = { '*' },
 
         level = 'secure', -- | 'edit' | 'soft' (see more info below)
 

--- a/lua/streamer-mode/streamer-mode.lua
+++ b/lua/streamer-mode/streamer-mode.lua
@@ -110,8 +110,9 @@ M.exclude = {
 ---         - exclude_all_default_keywords = { 'alias', 'export' }
 ---     • exclude_all_default_keywords: Do not use default keywords, only use the
 ---       keywords you specify.
----     • exclude_all_default_paths: Do not use default paths, only use the paths you
+---     • exclude_default_paths: Do not use default paths, only use the paths you
 ---       specify.  
+---     • exclude_all_default_paths: Same as `exclude_default_paths`
 ---     • keywords: table = { 'keywords', 'to', 'conceal' }
 ---     • paths: table = { '*/paths/*', '*to_use/*' }
 ---     • level: string = 'secure' -- | 'soft' | 'edit'
@@ -192,7 +193,7 @@ function M:configure_options(user_opts)
     end
 
 
-    if not user_opts.exclude_all_default_paths then
+    if not user_opts.exclude_all_default_paths and not user_opts.exclude_default_paths then
         if user_opts.paths then
             for i = 1, #default_opts.paths do
                 self.opts.paths[#self.opts.paths + 1] = default_opts.paths[i]


### PR DESCRIPTION
Closes #4 
- Add `exclude_all_default_paths` (bool) to config. 
    - Set to `true` (default `false`) to exclude all the `paths` in the default config.  
    - Ability to use `exclude_default_paths` as an alias.
    - There is only one value in the default `paths`, `'*'` (all paths/anywhere).  

- Add `exclude_all_default_keywords` (bool) to config. Set to `true` 
    (default `false`) to exclude all the `keywords` in the default config.  

- Add `exclude_default_keywords` (table) to config. Add the defaults you wish 
  to exclude in string format.
    * e.g., `exclude_default_keywords = { "alias", "$env:" }`

- Update documentation to reflect changes. 

- Make sure `conceallevel` is always returned to its original state.

- Some default options should always be applied - e.g., `conceal_char`
